### PR TITLE
feat: 챌린지 참가 & 챌린지 참가자 조회 api 구현

### DIFF
--- a/prisma/migrations/20250822004_alter_user/migration.sql
+++ b/prisma/migrations/20250822004_alter_user/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "public"."user" ALTER COLUMN "last_login_at" SET NOT NULL,
+ALTER COLUMN "last_login_at" SET DEFAULT CURRENT_TIMESTAMP;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,7 +19,7 @@ model User {
   updatedAt             DateTime                @updatedAt @map("updated_at")
   deletedAt             DateTime?               @map("deleted_at")
 
-  lastLoginAt           DateTime?               @map("last_login_at")
+  lastLoginAt           DateTime                @default(now()) @map("last_login_at")
 
   bookLikes             BookLike[]
   bookSaves             BookSave[]

--- a/src/book/book.service.ts
+++ b/src/book/book.service.ts
@@ -5,7 +5,6 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { BookRepository } from './book.repository';
-import { UserRepository } from 'src/user/user.repository';
 import { BookDto, BookListDto } from './dto/book.dto';
 import { SaveBookPayload } from './payload/save-book.payload';
 import { SaveBookData } from './type/save-book-data.type';
@@ -18,10 +17,7 @@ import { PageListDto } from 'src/page/dto/page.dto';
 
 @Injectable()
 export class BookService {
-  constructor(
-    private readonly bookRepository: BookRepository,
-    private readonly userRepository: UserRepository,
-  ) {}
+  constructor(private readonly bookRepository: BookRepository) {}
 
   private readonly baseUrl = 'https://www.aladin.co.kr/ttb/api/ItemSearch.aspx';
   private readonly ttbKey = process.env.ALADIN_TTB_KEY;

--- a/src/challenge/challenge.controller.ts
+++ b/src/challenge/challenge.controller.ts
@@ -5,7 +5,6 @@ import {
   Get,
   HttpCode,
   Param,
-  Patch,
   UseGuards,
   Version,
   Post,
@@ -25,6 +24,7 @@ import { ChallengeDto } from './dto/challenge.dto';
 import { CreateChallengePayload } from './payload/create-challenge.payload';
 import { CurrentUser } from 'src/auth/decorator/user.decorator';
 import { UserBaseInfo } from 'src/auth/type/user-base-info.type';
+import { ParticipantListDto } from './dto/participant.dto';
 
 @Controller('challenges')
 @ApiTags('Challenge API')
@@ -50,6 +50,30 @@ export class ChallengeController {
   @ApiOkResponse({ type: ChallengeDto })
   async getChallenge(@Param('id') id: number): Promise<ChallengeDto> {
     return this.challengeService.getChallengeById(id);
+  }
+
+  @Get(':id/participants')
+  @Version('1')
+  @ApiOperation({ summary: '챌린지 참가자 조회' })
+  @ApiOkResponse({ type: ParticipantListDto })
+  async getChallengeParticipants(
+    @Param('id') id: number,
+  ): Promise<ParticipantListDto> {
+    return this.challengeService.getChallengeParticipants(id);
+  }
+
+  @Post(':id/join')
+  @Version('1')
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: '챌린지 참가' })
+  @ApiNoContentResponse()
+  @HttpCode(204)
+  async joinChallenge(
+    @Param('id') id: number,
+    @CurrentUser() user: UserBaseInfo,
+  ): Promise<void> {
+    return this.challengeService.joinChallenge(id, user);
   }
 
   @Delete(':id')

--- a/src/challenge/dto/participant.dto.ts
+++ b/src/challenge/dto/participant.dto.ts
@@ -1,0 +1,51 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { ParticipantData } from '../type/participant-data.type';
+
+export class ParticipantDto {
+  @ApiProperty({
+    description: '참여자 ID',
+  })
+  id!: number;
+
+  @ApiProperty({
+    description: '참여자 이름',
+  })
+  name!: string;
+
+  @ApiProperty({
+    description: '최대 페이지',
+  })
+  maxPageRead!: number;
+
+  @ApiProperty({
+    description: '마지막 로그인 시간',
+  })
+  lastLoginAt!: Date;
+
+  static from(data: ParticipantData): ParticipantDto {
+    return {
+      id: data.id,
+      name: data.name,
+      maxPageRead: data.maxPageRead,
+      lastLoginAt: data.lastLoginAt,
+    };
+  }
+
+  static fromArray(data: ParticipantData[]): ParticipantDto[] {
+    return data.map((item) => ParticipantDto.from(item));
+  }
+}
+
+export class ParticipantListDto {
+  @ApiProperty({
+    description: '참여자 목록',
+    type: [ParticipantDto],
+  })
+  participants!: ParticipantDto[];
+
+  static from(data: ParticipantData[]): ParticipantListDto {
+    return {
+      participants: ParticipantDto.fromArray(data),
+    };
+  }
+}

--- a/src/challenge/type/participant-data.type.ts
+++ b/src/challenge/type/participant-data.type.ts
@@ -1,0 +1,6 @@
+export type ParticipantData = {
+  id: number;
+  name: string;
+  maxPageRead: number;
+  lastLoginAt: Date;
+};

--- a/src/read/dto/reading-progress.dto.ts
+++ b/src/read/dto/reading-progress.dto.ts
@@ -10,6 +10,11 @@ export class ReadingProgressDto {
   book!: BookDto;
 
   @ApiProperty({
+    description: '최대 페이지',
+  })
+  maxPageRead!: number;
+
+  @ApiProperty({
     description: '달성률',
     type: Number,
   })
@@ -24,6 +29,7 @@ export class ReadingProgressDto {
   static from(data: ReadingProgressData): ReadingProgressDto {
     return {
       book: data.book,
+      maxPageRead: data.maxPageRead,
       progress: data.progress,
       challengeParticipation: data.challengeParticipation,
     };

--- a/src/read/type/reading-progress-data.type.ts
+++ b/src/read/type/reading-progress-data.type.ts
@@ -2,6 +2,7 @@ import { BookData } from 'src/book/type/book-data.type';
 
 export type ReadingProgressData = {
   book: BookData;
+  maxPageRead: number;
   progress: number;
   challengeParticipation: boolean;
 };


### PR DESCRIPTION
1. 챌린지 참가 api 구현

2. 챌린지 참가자 조회 api 구현
- 아이디, 닉네임, 최대 페이지 번호, 최근 접속시간 반환

3. 챌린지 모듈 추가에 따른 로그 생성 api들의 예외 처리 수정
