### PR TITLE
feat: 챌린지 포기 api & 유저가 현재 참여 중인 챌린지 조회 api 구현 & 챌린지 참가 수 제한 조건 추가

### DIFF
--- a/src/challenge/challenge.controller.ts
+++ b/src/challenge/challenge.controller.ts
@@ -20,7 +20,7 @@ import {
 import { ApiTags } from '@nestjs/swagger';
 import { ChallengeService } from './challenge.service';
 import { JwtAuthGuard } from 'src/auth/guard/jwt-auth.guard';
-import { ChallengeDto } from './dto/challenge.dto';
+import { ChallengeDto, ChallengeListDto } from './dto/challenge.dto';
 import { CreateChallengePayload } from './payload/create-challenge.payload';
 import { CurrentUser } from 'src/auth/decorator/user.decorator';
 import { UserBaseInfo } from 'src/auth/type/user-base-info.type';
@@ -30,6 +30,18 @@ import { ParticipantListDto } from './dto/participant.dto';
 @ApiTags('Challenge API')
 export class ChallengeController {
   constructor(private readonly challengeService: ChallengeService) {}
+
+  @Get()
+  @Version('1')
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: '유저가 현재 참여 중인 챌린지 목록 조회' })
+  @ApiOkResponse({ type: ChallengeListDto })
+  async getUserActiveChallenges(
+    @CurrentUser() user: UserBaseInfo,
+  ): Promise<ChallengeListDto> {
+    return this.challengeService.getUserActiveChallenges(user);
+  }
 
   @Post()
   @Version('1')
@@ -74,6 +86,20 @@ export class ChallengeController {
     @CurrentUser() user: UserBaseInfo,
   ): Promise<void> {
     return this.challengeService.joinChallenge(id, user);
+  }
+
+  @Post(':id/leave')
+  @Version('1')
+  @ApiBearerAuth()
+  @UseGuards(JwtAuthGuard)
+  @ApiOperation({ summary: '챌린지 포기' })
+  @ApiNoContentResponse()
+  @HttpCode(204)
+  async leaveChallenge(
+    @Param('id') id: number,
+    @CurrentUser() user: UserBaseInfo,
+  ): Promise<void> {
+    return this.challengeService.leaveChallenge(id, user);
   }
 
   @Delete(':id')

--- a/src/challenge/challenge.service.ts
+++ b/src/challenge/challenge.service.ts
@@ -7,7 +7,7 @@ import {
 } from '@nestjs/common';
 import { ChallengeRepository } from './challenge.repository';
 import { BadWordsFilterService } from 'src/user/bad-words-filter.service';
-import { ChallengeDto } from './dto/challenge.dto';
+import { ChallengeDto, ChallengeListDto } from './dto/challenge.dto';
 import { CreateChallengePayload } from './payload/create-challenge.payload';
 import { UserBaseInfo } from 'src/auth/type/user-base-info.type';
 import { CreateChallengeData } from './type/create-challenge-data.type';
@@ -50,6 +50,16 @@ export class ChallengeService {
     if (payload.startTime < new Date()) {
       throw new BadRequestException('시작 시간은 현재 시간보다 늦어야 합니다.');
     }
+
+    const count = await this.challengeRepository.getCurrentParticipatingCount(
+      user.id,
+    );
+    if (count >= 5) {
+      throw new ConflictException(
+        '참가할 수 있는 챌린지 수(5개)를 초과하였습니다.',
+      );
+    }
+
     const data: CreateChallengeData = {
       hostId: user.id,
       name: payload.name,
@@ -109,6 +119,48 @@ export class ChallengeService {
       throw new ConflictException('이미 참가한 챌린지입니다.');
     }
 
+    const count = await this.challengeRepository.getCurrentParticipatingCount(
+      user.id,
+    );
+    if (count >= 5) {
+      throw new ConflictException(
+        '참가할 수 있는 챌린지 수(5개)를 초과하였습니다.',
+      );
+    }
+
     await this.challengeRepository.joinChallenge(id, user.id);
+  }
+
+  async leaveChallenge(id: number, user: UserBaseInfo): Promise<void> {
+    const challenge = await this.challengeRepository.getChallengeById(id);
+    if (!challenge) {
+      throw new NotFoundException('챌린지를 찾을 수 없습니다.');
+    }
+
+    const isUserParticipating =
+      await this.challengeRepository.isUserParticipating(id, user.id);
+    if (!isUserParticipating) {
+      throw new ConflictException('참가하지 않은 챌린지입니다.');
+    }
+
+    if (challenge.hostId === user.id) {
+      throw new ConflictException('챌린지 주최자는 포기할 수 없습니다.');
+    }
+
+    if (new Date() < challenge.startTime) {
+      //챌린지 시작 이전
+      await this.challengeRepository.leaveChallenge(id, user.id);
+    }
+    if (challenge.startTime <= new Date()) {
+      //챌린지 시작 이후
+      await this.challengeRepository.updateChallengeJoinStatus(id, user.id);
+    }
+  }
+
+  async getUserActiveChallenges(user: UserBaseInfo): Promise<ChallengeListDto> {
+    const challenges = await this.challengeRepository.getUserActiveChallenges(
+      user.id,
+    );
+    return ChallengeListDto.from(challenges);
   }
 }

--- a/src/challenge/dto/challenge.dto.ts
+++ b/src/challenge/dto/challenge.dto.ts
@@ -70,4 +70,22 @@ export class ChallengeDto {
             : ChallengeStatus.ACTIVE,
     };
   }
+
+  static fromArray(data: ChallengeData[]): ChallengeDto[] {
+    return data.map((challenge) => ChallengeDto.from(challenge));
+  }
+}
+
+export class ChallengeListDto {
+  @ApiProperty({
+    description: '챌린지 목록',
+    type: [ChallengeDto],
+  })
+  challenges!: ChallengeDto[];
+
+  static from(data: ChallengeData[]): ChallengeListDto {
+    return {
+      challenges: ChallengeDto.fromArray(data),
+    };
+  }
 }


### PR DESCRIPTION
1. 챌린지 포기 api 구현
- 챌린지 시작 이전에는 참여 로그 자체를 삭제
- 챌린지 시작 이후에는 참여 로그를 유지하지만, 포기했다는 상태와 포기 시각을 기록

2. 유저가 현재 참여 중인 챌린지 조회 api 구현
- 현재 종료되지 않은 챌린지면서, 유저가 포기하지 않은 챌린지들의 목록을 조회

3. 챌린지 참가 수 제한 조건 추가
- 최대로 참가할 수 있는 챌린지의 개수는 일단 5개
- 이에 따라 챌린지 생성, 참가 api에 있어서 예외 처리 추가