### PR TITLE
feat: 챌린지 수정 api 구현 & 챌린지 삭제 api 제거

### DIFF
--- a/src/challenge/challenge.controller.ts
+++ b/src/challenge/challenge.controller.ts
@@ -25,6 +25,7 @@ import { CreateChallengePayload } from './payload/create-challenge.payload';
 import { CurrentUser } from 'src/auth/decorator/user.decorator';
 import { UserBaseInfo } from 'src/auth/type/user-base-info.type';
 import { ParticipantListDto } from './dto/participant.dto';
+import { UpdateChallengePayload } from './payload/update-challenge.payload';
 
 @Controller('challenges')
 @ApiTags('Challenge API')
@@ -62,6 +63,20 @@ export class ChallengeController {
   @ApiOkResponse({ type: ChallengeDto })
   async getChallenge(@Param('id') id: number): Promise<ChallengeDto> {
     return this.challengeService.getChallengeById(id);
+  }
+
+  @Post(':id')
+  @Version('1')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: '챌린지 수정' })
+  @ApiOkResponse({ type: ChallengeDto })
+  async updateChallenge(
+    @Param('id') id: number,
+    @Body() payload: UpdateChallengePayload,
+    @CurrentUser() user: UserBaseInfo,
+  ): Promise<ChallengeDto> {
+    return this.challengeService.updateChallenge(id, payload, user);
   }
 
   @Get(':id/participants')
@@ -102,6 +117,7 @@ export class ChallengeController {
     return this.challengeService.leaveChallenge(id, user);
   }
 
+  /*
   @Delete(':id')
   @Version('1')
   @ApiOperation({ summary: '챌린지 삭제' })
@@ -115,4 +131,5 @@ export class ChallengeController {
   ): Promise<void> {
     return this.challengeService.deleteChallenge(id, user);
   }
+    */
 }

--- a/src/challenge/challenge.repository.ts
+++ b/src/challenge/challenge.repository.ts
@@ -5,6 +5,7 @@ import { ChallengeData } from './type/challenge-data.type';
 import { ParticipantStatus } from '@prisma/client';
 import { BookData } from 'src/book/type/book-data.type';
 import { ParticipantData } from './type/participant-data.type';
+import { UpdateChallengeData } from './type/update-challenge-data.type';
 
 @Injectable()
 export class ChallengeRepository {
@@ -223,6 +224,29 @@ export class ChallengeRepository {
         completedAt: true,
         cancelledAt: true,
         challengeJoin: true,
+      },
+    });
+  }
+
+  async updateChallenge(
+    id: number,
+    data: UpdateChallengeData,
+  ): Promise<ChallengeData> {
+    return this.prisma.challenge.update({
+      where: { id },
+      data: {
+        name: data.name,
+      },
+      select: {
+        id: true,
+        name: true,
+        hostId: true,
+        bookId: true,
+        visibility: true,
+        startTime: true,
+        endTime: true,
+        completedAt: true,
+        cancelledAt: true,
       },
     });
   }

--- a/src/challenge/payload/create-challenge.payload.ts
+++ b/src/challenge/payload/create-challenge.payload.ts
@@ -1,11 +1,19 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsDate, IsEnum, IsInt, IsString, MaxLength } from 'class-validator';
+import {
+  IsDate,
+  IsEnum,
+  IsInt,
+  IsString,
+  MaxLength,
+  MinLength,
+} from 'class-validator';
 import { ChallengeVisibility } from '@prisma/client';
 import { Type } from 'class-transformer';
 
 export class CreateChallengePayload {
   @IsString()
-  @MaxLength(25)
+  @MinLength(2, { message: '챌린지 이름은 최소 2자 이상이어야 합니다.' })
+  @MaxLength(25, { message: '챌린지 이름은 최대 25자 이하여야 합니다.' })
   @ApiProperty({
     description: '챌린지 이름',
     type: String,

--- a/src/challenge/payload/update-challenge.payload.ts
+++ b/src/challenge/payload/update-challenge.payload.ts
@@ -1,0 +1,14 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsOptional, IsString, MaxLength, MinLength } from 'class-validator';
+
+export class UpdateChallengePayload {
+  @IsOptional()
+  @IsString()
+  @MinLength(2, { message: '챌린지 이름은 최소 2자 이상이어야 합니다.' })
+  @MaxLength(25, { message: '챌린지 이름은 최대 25자 이하여야 합니다.' })
+  @ApiPropertyOptional({
+    description: '챌린지 이름',
+    type: String,
+  })
+  name?: string | null;
+}

--- a/src/challenge/type/update-challenge-data.type.ts
+++ b/src/challenge/type/update-challenge-data.type.ts
@@ -1,0 +1,3 @@
+export type UpdateChallengeData = {
+  name?: string;
+};


### PR DESCRIPTION
1. 챌린지 수정 api 구현
- 현재 기획 상으로는 챌린지 이름만 수정이 가능한데 추후에 변경 가능성 있음

2. 챌린지 삭제 api 제거
- 현재 기획 상으로는 이미 만들어진 챌린지는 삭제가 불가함
- 이에 따라 기존의 챌린지 삭제 api를 주석 처리함