### PR TITLE
feat: 챌린지 검색 api 구현

### DIFF
--- a/src/challenge/challenge.controller.ts
+++ b/src/challenge/challenge.controller.ts
@@ -8,6 +8,7 @@ import {
   Version,
   Post,
   Patch,
+  Query,
 } from '@nestjs/common';
 import {
   ApiBearerAuth,
@@ -27,6 +28,7 @@ import { ParticipantListDto } from './dto/participant.dto';
 import { UpdateChallengePayload } from './payload/update-challenge.payload';
 import { ChallengeCompleteLogListDto } from './dto/challenge-complete-log.dto';
 import { ChallengeHistoryListDto } from './dto/challenge-history.dto';
+import { ChallengeSearchQuery } from 'src/search/query/challenge-search-query';
 
 @Controller('challenges')
 @ApiTags('Challenge API')
@@ -68,6 +70,16 @@ export class ChallengeController {
     @CurrentUser() user: UserBaseInfo,
   ): Promise<ChallengeHistoryListDto> {
     return this.challengeService.getUserChallengeHistory(user);
+  }
+
+  @Get('search')
+  @Version('1')
+  @ApiOperation({ summary: '챌린지 검색' })
+  @ApiOkResponse({ type: ChallengeListDto })
+  async searchChallenges(
+    @Query() query: ChallengeSearchQuery,
+  ): Promise<ChallengeListDto> {
+    return this.challengeService.searchChallenges(query);
   }
 
   @Get(':id')

--- a/src/challenge/challenge.service.ts
+++ b/src/challenge/challenge.service.ts
@@ -21,14 +21,13 @@ import { ChallengeHistoryListDto } from './dto/challenge-history.dto';
 import { ParticipantData } from './type/participant-data.type';
 import { ChallengeData } from './type/challenge-data.type';
 import { ChallengeHistoryData } from './type/challenge-history-data.type';
-import { PrismaService } from 'src/common/services/prisma.service';
+import { ChallengeSearchQuery } from 'src/search/query/challenge-search-query';
 
 @Injectable()
 export class ChallengeService {
   constructor(
     private readonly challengeRepository: ChallengeRepository,
     private readonly badWordsFilterService: BadWordsFilterService,
-    private readonly prisma: PrismaService,
   ) {}
 
   async createChallenge(
@@ -358,5 +357,12 @@ export class ChallengeService {
     });
 
     return ChallengeHistoryListDto.from(histories);
+  }
+
+  async searchChallenges(
+    query: ChallengeSearchQuery,
+  ): Promise<ChallengeListDto> {
+    const challenges = await this.challengeRepository.searchChallenges(query);
+    return ChallengeListDto.from(challenges);
   }
 }

--- a/src/search/query/challenge-search-query.ts
+++ b/src/search/query/challenge-search-query.ts
@@ -1,0 +1,11 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
+import { IsString } from 'class-validator';
+
+export class ChallengeSearchQuery {
+  @IsString()
+  @ApiPropertyOptional({
+    description: '검색어',
+    type: String,
+  })
+  query!: string;
+}


### PR DESCRIPTION
검색 조건
- 현재 시각이 startTime 이전 ( = 현재 참가 가능)
- cancelledAt == null
- visibility : PUBLIC
- 챌린지 이름 혹은 책 제목에 검색어가 포함됨

날짜 기준으로 오름차순으로 정렬됨