### PR TITLE
feat: 유저가 최근에 읽은 책 목록 조회 api & 마지막으로 진입한 페이지 조회(이어읽기) api 구현

### DIFF
--- a/src/challenge/challenge.repository.ts
+++ b/src/challenge/challenge.repository.ts
@@ -279,7 +279,7 @@ export class ChallengeRepository {
             leftAt: null,
           },
         },
-        //2. 챌린지가 종료되지 않았고, 취소/완료되지 않았어야 함
+        //2. 챌린지가 종료되지 않았고, 취소/완료되지 않았어야 함 (준비 중 + 진행 중)
         cancelledAt: null,
         completedAt: null,
         endTime: {

--- a/src/read/read.controller.ts
+++ b/src/read/read.controller.ts
@@ -29,6 +29,8 @@ import { DateQuery } from './query/date.query';
 import { ReadingProgressListDto } from './dto/reading-progress.dto';
 import { CalendarQuery } from './query/calendar.query';
 import { ReadingStreakDto } from './dto/reading-streak.dto';
+import { BookListDto } from 'src/book/dto/book.dto';
+import { PageDto } from 'src/page/dto/page.dto';
 
 @Controller('read')
 @ApiTags('Read API')
@@ -59,6 +61,31 @@ export class ReadController {
     @CurrentUser() user: UserBaseInfo,
   ): Promise<ReadingProgressListDto> {
     return this.readService.getReadingProgressLogsByDate(dateQuery, user);
+  }
+
+  @Get('recent')
+  @Version('1')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: '유저가 최근에 읽은 책들 조회(최대 10권)' })
+  @ApiOkResponse({ type: BookListDto })
+  async getRecentBooks(
+    @CurrentUser() user: UserBaseInfo,
+  ): Promise<BookListDto> {
+    return this.readService.getRecentBooks(user);
+  }
+
+  @Get('last-page/:id')
+  @Version('1')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: '마지막으로 진입한 페이지 조회 (이어읽기)' })
+  @ApiOkResponse({ type: PageDto })
+  async getLastPage(
+    @Param('id', ParseIntPipe) id: number,
+    @CurrentUser() user: UserBaseInfo,
+  ): Promise<PageDto> {
+    return this.readService.getLastPage(id, user);
   }
 
   @Post('start')


### PR DESCRIPTION
1. 유저가 최근에 읽은 책 목록 조회 (최대 10권) api

2. 마지막으로 진입한 페이지 조회 (이어읽기) api
- 해당 책이 현재 진행하는 챌린지의 책이라면, 챌린지 읽기로 적용
- 해당 책이 읽은 적이 없는 책이라면, 첫 페이지 반환