### PR TITLE
fix: streak 기준 변경 & 북마크한 책 반환 api의 반환 순서 변경

### DIFF
--- a/src/book/book.repository.ts
+++ b/src/book/book.repository.ts
@@ -154,7 +154,7 @@ export class BookRepository {
           },
         },
       },
-      orderBy: { createdAt: 'asc' }, // 가장 오래된 순서대로
+      orderBy: { createdAt: 'desc' }, // 가장 최근에 저장된 순서대로
     });
     return savedBooks.map((item) => item.book);
   }

--- a/src/read/read.service.ts
+++ b/src/read/read.service.ts
@@ -249,16 +249,6 @@ export class ReadService {
     const todayStr = format(today, 'yyyy-MM-dd');
     const readToday = readingDateSet.has(todayStr);
 
-    if (!readToday) {
-      const data: ReadingStreakData = {
-        currentStreak: 0,
-        readToday: false,
-        longestStreak: streakData ? streakData.days : 0,
-        lastUpdatedAt: streakData ? streakData.updatedAt : new Date(0),
-      };
-      return ReadingStreakDto.from(data);
-    }
-
     let currentStreak = 0;
     // 연속일 계산 시작점: 오늘 읽었으면 오늘부터, 안 읽었으면 어제부터 확인
     let dateToCheck = readToday ? today : subDays(today, 1);


### PR DESCRIPTION
1. streak 기준 변경
- 오늘 또는 어제부터 시작해서, 과거로 거슬러 올라갈 때 끊기지 않은 연속 독서일

2. 북마크한 책 반환 api에서
최근에 북마크한 책을 리스트의 앞쪽 인덱스에 위치하도록 변경