### PR TITLE
feat: 마지막 진입 페이지 조회(이어읽기) api의 반환 DTO 수정

### DIFF
--- a/src/book/book.controller.ts
+++ b/src/book/book.controller.ts
@@ -132,17 +132,6 @@ export class BookController {
     return this.bookService.getDetailedBookById(id, user.id);
   }
 
-  @Post(':id/views')
-  @Version('1')
-  @ApiOperation({ summary: '책 조회수 증가' })
-  @ApiNoContentResponse()
-  @HttpCode(204)
-  async incrementBookViews(
-    @Param('id', ParseIntPipe) id: number,
-  ): Promise<void> {
-    return this.bookService.incrementBookViews(id);
-  }
-
   @Get(':id/pages/download')
   @Version('1')
   @ApiOkResponse({ type: PageListDto })

--- a/src/book/book.repository.ts
+++ b/src/book/book.repository.ts
@@ -175,18 +175,6 @@ export class BookRepository {
     return savedBook !== null;
   }
 
-  async incrementBookViews(bookId: number, title: string): Promise<void> {
-    await this.prisma.book.update({
-      where: { id: bookId },
-      data: {
-        views: {
-          increment: 1,
-        },
-      },
-    });
-    await redis.zincrby('autocomplete:views', 1, title);
-  }
-
   async updateBookPages(bookId: number, pages: string[]): Promise<void> {
     await this.prisma.$transaction([
       this.prisma.page.deleteMany({

--- a/src/book/book.service.ts
+++ b/src/book/book.service.ts
@@ -236,14 +236,6 @@ export class BookService {
     }
   }
 
-  async incrementBookViews(bookId: number): Promise<void> {
-    const book = await this.bookRepository.getBookById(bookId);
-    if (!book) {
-      throw new NotFoundException('책을 찾을 수 없습니다.');
-    }
-    await this.bookRepository.incrementBookViews(bookId, book.title);
-  }
-
   async updateBookPages(bookId: number, fileName: string): Promise<void> {
     const book = await this.bookRepository.getBookById(bookId);
     if (!book) {

--- a/src/read/dto/last-page-dto.ts
+++ b/src/read/dto/last-page-dto.ts
@@ -1,0 +1,39 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { SentenceLikeDto } from 'src/page/dto/sentence-like.dto';
+import { PageData } from 'src/page/type/page-type';
+import { SentenceLikeData } from 'src/page/type/sentence-like-type';
+
+export class LastPageDto {
+  @ApiProperty({
+    description: '페이지 ID',
+    type: Number,
+  })
+  id!: number;
+
+  @ApiProperty({
+    description: '페이지 내용',
+    type: String,
+  })
+  content!: string;
+
+  @ApiProperty({
+    description: '페이지 번호',
+    type: Number,
+  })
+  number!: number;
+
+  @ApiProperty({
+    description: '유저가 좋아요한 문장들',
+    type: [SentenceLikeDto],
+  })
+  likedSentences!: SentenceLikeDto[];
+
+  static from(data: PageData, likedSentences: SentenceLikeData[]): LastPageDto {
+    return {
+      id: data.id,
+      content: data.content,
+      number: data.number,
+      likedSentences: SentenceLikeDto.fromArray(likedSentences),
+    };
+  }
+}

--- a/src/read/read.controller.ts
+++ b/src/read/read.controller.ts
@@ -30,6 +30,7 @@ import { ReadingProgressListDto } from './dto/reading-progress.dto';
 import { CalendarQuery } from './query/calendar.query';
 import { ReadingStreakDto } from './dto/reading-streak.dto';
 import { PageDto } from 'src/page/dto/page.dto';
+import { LastPageDto } from './dto/last-page-dto';
 
 @Controller('read')
 @ApiTags('Read API')
@@ -67,11 +68,11 @@ export class ReadController {
   @UseGuards(JwtAuthGuard)
   @ApiBearerAuth()
   @ApiOperation({ summary: '책의 마지막으로 진입한 페이지 조회 (이어읽기)' })
-  @ApiOkResponse({ type: PageDto })
+  @ApiOkResponse({ type: LastPageDto })
   async getLastPage(
     @Param('id', ParseIntPipe) id: number,
     @CurrentUser() user: UserBaseInfo,
-  ): Promise<PageDto> {
+  ): Promise<LastPageDto> {
     return this.readService.getLastPage(id, user);
   }
 


### PR DESCRIPTION
- 좋아요한 문장들의 하이라이트를 위하여 유저가 좋아요한 문장도 DTO에 포함
- 또한 필요한 정보들만 남겨 간소화
- 조회수 증가도 이 api에서 한번에 처리