### PR TITLE
feat: 책 상세 조회 api 수정

### DIFF
--- a/src/book/book.repository.ts
+++ b/src/book/book.repository.ts
@@ -362,4 +362,19 @@ export class BookRepository {
 
     return books.length > 0 ? books[0] : null;
   }
+
+  async getOtherBooksByAuthor(
+    author: string,
+    excludeBookId: number,
+    limit = 5,
+  ): Promise<BookData[]> {
+    return this.prisma.book.findMany({
+      where: {
+        author,
+        id: { not: excludeBookId },
+      },
+      take: limit,
+      orderBy: { views: 'desc' },
+    });
+  }
 }

--- a/src/book/dto/detailed-book.dto.ts
+++ b/src/book/dto/detailed-book.dto.ts
@@ -42,12 +42,6 @@ export class DetailedBookDto {
   averageRating!: number;
 
   @ApiProperty({
-    description: '책 저장 여부',
-    type: Boolean,
-  })
-  isSaved!: boolean;
-
-  @ApiProperty({
     description: '책 커버 이미지 URL',
     type: String,
     nullable: true,
@@ -67,6 +61,12 @@ export class DetailedBookDto {
   similarBooks!: BasicBookDto[];
 
   @ApiProperty({
+    description: '같은 작가의 책 목록',
+    type: [BasicBookDto],
+  })
+  otherBooksByAuthor!: BasicBookDto[];
+
+  @ApiProperty({
     description: '미리보기',
     type: String,
   })
@@ -77,13 +77,16 @@ export class DetailedBookDto {
     reviews: ReviewData[],
     nicknames: string[],
     similarBooks: BookData[],
+    otherBooksByAuthor: BookData[],
     averageRating: number,
-    isSaved: boolean,
     preview: string,
     url?: string | null,
     similarBooksUrl?: (string | null)[],
+    otherBooksByAuthorUrl?: (string | null)[],
   ): DetailedBookDto {
     const similarBooksUrls = similarBooksUrl ?? similarBooks.map(() => null);
+    const otherBooksByAuthorUrls =
+      otherBooksByAuthorUrl ?? otherBooksByAuthor.map(() => null);
     return {
       id: data.id,
       title: data.title,
@@ -92,10 +95,13 @@ export class DetailedBookDto {
       totalPages: data.totalPagesCount,
       coverImageUrl: url ?? null,
       averageRating: averageRating,
-      isSaved: isSaved,
       preview: preview,
       bestReviews: SimpleReviewDto.fromArray(reviews, nicknames),
       similarBooks: BasicBookDto.fromArray(similarBooks, similarBooksUrls),
+      otherBooksByAuthor: BasicBookDto.fromArray(
+        otherBooksByAuthor,
+        otherBooksByAuthorUrls,
+      ),
     };
   }
 }


### PR DESCRIPTION
1. 책 저장 여부 필드 제거
2. 최대 4권의 같은 작가의 책을 조회(본 책은 제외)하여 응답에 포함(조회수 순)
- 만약 4권이 안 된다면 나머지 수만큼 랜덤으로 조회하여 응답에 포함